### PR TITLE
Update AtomicFileOutputStream.java

### DIFF
--- a/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -100,10 +100,6 @@ public class AtomicFileOutputStream extends FilterOutputStream {
         this(path, false);
     }
 
-    private static Path getPathOfTemporaryFile(Path targetFile) {
-        return FileUtil.addExtension(targetFile, TEMPORARY_EXTENSION);
-    }
-
     private static Path getPathOfBackupFile(Path targetFile) {
         return FileUtil.addExtension(targetFile, BACKUP_EXTENSION);
     }
@@ -134,20 +130,13 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     public void abort() {
         try {
             super.close();
-            Files.deleteIfExists(temporaryFile);
             Files.deleteIfExists(backupFile);
         } catch (IOException exception) {
-            LOGGER.debug("Unable to abort writing to file " + temporaryFile, exception);
+            LOGGER.debug("Unable to abort writing to file " + this.targetFile, exception);
         }
     }
 
     private void cleanup() {
-        try {
-            Files.deleteIfExists(temporaryFile);
-        } catch (IOException exception) {
-            LOGGER.debug("Unable to delete file " + temporaryFile, exception);
-        }
-
         try {
             if (temporaryFileLock != null) {
                 temporaryFileLock.release();


### PR DESCRIPTION
Edited lines 103-148 to remove references to temporary file and changed abort class to show an error if it is unable to abort writing to the target file as opposed to the temporary file.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
